### PR TITLE
SetupWizard: fix build break for incorrect java lib linking

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,8 +16,9 @@ LOCAL_STATIC_JAVA_LIBRARIES := \
     android-support-v13 \
     play \
     libphonenumber \
-    org.cyanogenmod.platform.sdk \
-    telephony-common
+    org.cyanogenmod.platform.sdk
+
+LOCAL_JAVA_LIBRARIES := telephony-common
 
 # Include res dir from chips
 google_play_dir := ../../../external/google/google_play_services/libproject/google-play-services_lib/res


### PR DESCRIPTION
Issue-Id: CYNGNOS-1969

Change-Id: Ia13390739737063a9ab0cd0c3907389f3a587191